### PR TITLE
Added basic support for editing and getting the content

### DIFF
--- a/Monaco/MonacoEditor.xaml.cs
+++ b/Monaco/MonacoEditor.xaml.cs
@@ -89,7 +89,7 @@ namespace Monaco
 
             this._content = ensuredContent;
 
-            string command = $"editor.setValue(('{ensuredContent}');";
+            string command = $"editor.setValue('{ensuredContent}');";
 
             await this.MonacoEditorWebView
                 .ExecuteScriptAsync(command);

--- a/Monaco/MonacoEditor.xaml.cs
+++ b/Monaco/MonacoEditor.xaml.cs
@@ -12,6 +12,7 @@ namespace Monaco
     public sealed partial class MonacoEditor : UserControl
     {
         public bool LoadCompleted { get; set; } = false;
+
         private string _content = "";
 
         #region PropertyChanged Event
@@ -24,7 +25,25 @@ namespace Monaco
 
         #endregion
 
-        
+        #region EditorLanguage Property
+        public static readonly DependencyProperty EditorLanguageProperty = DependencyProperty.Register("EditorLanguage",
+              typeof(string),
+              typeof(MonacoEditor),
+              new PropertyMetadata(null));
+
+        public string EditorLanguage
+        {
+            get {
+                return GetValue(EditorLanguageProperty) == null ? "javascript" : (string)GetValue(EditorLanguageProperty);
+            }
+            set { 
+                SetValue(EditorLanguageProperty, value);
+                OnPropertyChanged();
+
+                _ = this.SetLanguageAsync(value);
+            }
+        }
+        #endregion
 
         #region Route Property
 
@@ -57,7 +76,16 @@ namespace Monaco
               new PropertyMetadata(null));
         public EditorThemes EditorTheme
         {
-            get { return (EditorThemes)GetValue(EditorThemeProperty); }
+            get { 
+                if(GetValue(EditorThemeProperty) != null)
+                {
+                    return (EditorThemes)GetValue(EditorThemeProperty); 
+                }
+                else
+                {
+                    return EditorThemes.VisualStudioLight;
+                }
+            }
             set
             {
                 SetValue(EditorThemeProperty, value);
@@ -79,6 +107,8 @@ namespace Monaco
         private void WebView_NavigationCompleted(object sender, object e)
         {
             LoadCompleted = true;
+            this.SetThemeAsync(this.EditorTheme);
+            this.SetLanguageAsync(this.EditorLanguage);
         }
 
         private void MonacoEditor_Loaded(object sender, RoutedEventArgs e)

--- a/Monaco/MonacoEditor.xaml.cs
+++ b/Monaco/MonacoEditor.xaml.cs
@@ -96,6 +96,22 @@ namespace Monaco
         }
 
         /// <summary>
+        /// Gets the content form the monaco editor view
+        /// </summary>
+        /// <returns>The content of the editor</returns>
+        public async Task<string> GetEditorContentAsync()
+        {
+            string command = $"editor.getValue();";
+
+            string contentAsJsRepresentation = await this.MonacoEditorWebView
+                .ExecuteScriptAsync(command);
+            string unescapedString = System.Text.RegularExpressions.Regex.Unescape(contentAsJsRepresentation);
+            string content = unescapedString.Substring(1, unescapedString.Length - 2).ReplaceLineEndings();
+
+            return content;
+        }
+
+        /// <summary>
         /// sets the requested theme to the monaco editor view
         /// </summary>
         /// <param name="theme">the requested theme</param>

--- a/Monaco/MonacoEditor.xaml.cs
+++ b/Monaco/MonacoEditor.xaml.cs
@@ -6,12 +6,12 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Web;
-using Windows.Globalization;
 
 namespace Monaco
 {
     public sealed partial class MonacoEditor : UserControl
     {
+        public bool LoadCompleted { get; set; } = false;
         private string _content = "";
 
         #region PropertyChanged Event
@@ -24,15 +24,20 @@ namespace Monaco
 
         #endregion
 
+        
+
         #region Route Property
 
         public static readonly DependencyProperty EditorContentProperty = DependencyProperty.Register("EditorContent",
               typeof(string),
               typeof(MonacoEditor),
               new PropertyMetadata(null));
+
+        /// <summary>
+        /// Get the content of the editor.
+        /// </summary>
         public string EditorContent
         {
-            get { return (string)GetValue(EditorContentProperty); }
             set
             {
                 SetValue(EditorContentProperty, value);
@@ -67,8 +72,13 @@ namespace Monaco
         public MonacoEditor()
         {
             this.InitializeComponent();
-
             this.Loaded += MonacoEditor_Loaded;
+            MonacoEditorWebView.NavigationCompleted += WebView_NavigationCompleted;
+        }
+
+        private void WebView_NavigationCompleted(object sender, object e)
+        {
+            LoadCompleted = true;
         }
 
         private void MonacoEditor_Loaded(object sender, RoutedEventArgs e)
@@ -111,6 +121,7 @@ namespace Monaco
             return content;
         }
 
+
         /// <summary>
         /// sets the requested theme to the monaco editor view
         /// </summary>
@@ -136,8 +147,7 @@ namespace Monaco
 
             string command = $"editor._themeService.setTheme('{themeValue}');";
 
-            await this.MonacoEditorWebView
-                .ExecuteScriptAsync(command);
+            await this.MonacoEditorWebView.ExecuteScriptAsync(command);
         }
 
         /// <summary>
@@ -161,8 +171,7 @@ namespace Monaco
         {
             string command = $"editor.setSelection(editor.getModel().getFullModelRange());";
 
-            await this.MonacoEditorWebView
-                .ExecuteScriptAsync(command);
+            await this.MonacoEditorWebView.ExecuteScriptAsync(command);
         }
     }
 }

--- a/MonacoTestApp/MainWindow.xaml
+++ b/MonacoTestApp/MainWindow.xaml
@@ -62,6 +62,10 @@
                     Content="Set Content"
                     Click="SetContentButton_Click" />
 
+            <Button Style="{ThemeResource ModeButtonStyle}"
+        Content="Get Content"
+        Click="GetContentButton_Click" />
+
             <ComboBox x:Name="EditorLanguageComboBox"
                       SelectionChanged="EditorLanguageComboBox_SelectionChanged"
                       HorizontalAlignment="Stretch">

--- a/MonacoTestApp/MainWindow.xaml
+++ b/MonacoTestApp/MainWindow.xaml
@@ -74,7 +74,9 @@
         </StackPanel>
 
         <monaco:MonacoEditor Grid.Column="1"
-                             x:Name="MonacoEditor" />
+                             x:Name="MonacoEditor" 
+                             EditorTheme="VisualStudioDark"
+                             EditorLanguage="python"/>
 
     </Grid>
 

--- a/MonacoTestApp/MainWindow.xaml.cs
+++ b/MonacoTestApp/MainWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace MonacoTestApp
 
         private void SetContentButton_Click(object sender, RoutedEventArgs e)
         {
-            _ = this.MonacoEditor.LoadContentAsync(this.EditorContentTextBox.Text);
+            _ = this.MonacoEditor.EditorContent = this.EditorContentTextBox.Text;
         }
 
         private void EditorLanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/MonacoTestApp/MainWindow.xaml.cs
+++ b/MonacoTestApp/MainWindow.xaml.cs
@@ -44,5 +44,10 @@ namespace MonacoTestApp
         {
             _ = this.MonacoEditor.SelectAllAsync();
         }
+
+        private async void GetContentButton_Click(object sender, RoutedEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine(await MonacoEditor.GetEditorContentAsync());
+        }
     }
 }


### PR DESCRIPTION
Hey there, I built some basic support for editing and then retrieving the content of the editor, and also setting it properly.

I removed the EditorContent.get accessor, as it was broken anyway (see issue: https://github.com/lk-code/winui.monaco-editor/issues/7 ).

I also added a GetEditorContentAsync() to the class, that now gets the current content of the editor.

Also I fixed an extra bracket in the set method.