### PR TITLE
Repo re-forked; re-adding Cut, Copy, Paste custom code; Context Menu …

### DIFF
--- a/source/Monaco/IMonacoEditor.cs
+++ b/source/Monaco/IMonacoEditor.cs
@@ -12,6 +12,13 @@ public interface IMonacoEditor
     event EventHandler MonacoEditorLoaded;
 
     /// <summary>
+    /// Disable MOnaco Editor's own context menu.
+    /// </summary>
+    /// <param name="status">TRUE/FALSE, default is true</param>
+    /// <returns></returns>
+    Task ContextMenuEnabled(bool status=true);
+
+    /// <summary>
     /// sets the requested theme to the monaco editor view
     /// </summary>
     /// <param name="theme">the requested theme</param>

--- a/source/MonacoTestApp/MainWindow.xaml
+++ b/source/MonacoTestApp/MainWindow.xaml
@@ -207,7 +207,11 @@
                                       IsChecked="True"
                                       Checked="StickyScrollCheckBox_Checked"
                                       Unchecked="StickyScrollCheckBox_Unchecked"/>
-
+                            <CheckBox x:Name="DisableContextMenu"
+                                      Content="Disable context menu"
+                                      IsChecked="False"
+                                      Checked="DisableContextMenu_Checked"
+                                      Unchecked="DisableContextMenu_Unchecked" />
                         </StackPanel>
 
                     </ScrollViewer>

--- a/source/MonacoTestApp/MainWindow.xaml.cs
+++ b/source/MonacoTestApp/MainWindow.xaml.cs
@@ -192,6 +192,16 @@ public sealed partial class MainWindow : Window
 
     private void AutoCodeTypeDetection_Checked(object sender, RoutedEventArgs e)
     {
+        
+    }
 
+    private void DisableContextMenu_Checked(object sender, RoutedEventArgs e)
+    {
+        MonacoEditor.ContextMenuEnabled(false);
+    }
+
+    private void DisableContextMenu_Unchecked(object sender, RoutedEventArgs e)
+    {
+        MonacoEditor.ContextMenuEnabled();
     }
 }


### PR DESCRIPTION
…can be disabled

Added:
- ContextMenuEnabled property: allows to disable Monaco's own context menu

Re-added:
- Cut, Copy, Paste custom methods: whenever somebody wants to create a custom context menu in XAML, these methos come in as very handy
- ScrollToLine method
- ScrollToLineInCenter method
- ScrollToTop method
-----------------------------------------------------------
MainTestApp:
- Added a CheckBox in "Options" tab that allows to disable Monaco Editor default context menu